### PR TITLE
dylan-package.json: Fix package name

### DIFF
--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,5 +1,5 @@
 {
-    "name": "statistics",
+    "name": "data-analysis",
     "description": "A collection of data analysis libraries",
     "url": "https://github.com/dylan-foundry/data-analysis",
     "version": "0.1.0",


### PR DESCRIPTION
Decided I'd better fix the package name.

@waywardmonkeys What would you prefer for your Dylan repositories? For people to continue hacking on them here, or for me to clone them to dylan-lang and treat that as the official home? I just started making changes assuming you'd prefer to keep them here but not sure.  What say you?